### PR TITLE
patch: Enable Spotlight mode on join

### DIFF
--- a/src/meetbot/features/record.ts
+++ b/src/meetbot/features/record.ts
@@ -15,7 +15,7 @@ const startRecording = async (page: Page) => {
 		'Rec' ===
 		(await (await page.$('.F9AaL'))?.evaluate((element) => element.textContent))
 	) {
-		console.log('Recording is on, not trying to to record.');
+		console.log('Recording is already turned on. Not trying to record.');
 		return;
 	}
 

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -123,6 +123,16 @@ class MeetBot implements Bot {
 				await this.page.waitForXPath("//*[contains(text(),'call_end')]");
 			}
 
+			console.log('Changing layout to Spotlight mode');
+			await clickText(this.page, 'more_vert');
+			await this.page.waitForTimeout(1000);
+			await clickText(this.page, 'Change layout');
+			await this.page.waitForTimeout(1000);
+			await clickText(this.page, 'Spotlight');
+			await this.page.waitForTimeout(1000);
+			await clickText(this.page, 'Close');
+			await this.page.waitForTimeout(1000);
+
 			await this.page.waitForTimeout(1500);
 			// await page.screenshot({ path: 'after-join.png' });
 


### PR DESCRIPTION
Enabling the spotlight mode will potenially help reduce performance issues as it removes the people from the meet view. Atleast hubot won't have to see everyone's faces for hours. 

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
