### PR TITLE
patch: Add google meet URL validator

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -20,12 +20,19 @@ server.post('/join', async (req, res) => {
 	let meetMetadata;
 	// Validate body
 	if (!req.body.url) {
-		return res.status(400).send('Missing `url` value in payload body.');
+		return res
+			.status(400)
+			.send('Unable to join. Missing `url` value in payload body.');
 	}
 	try {
 		meetMetadata = new URL(req.body.url);
+		if (meetMetadata.hostname !== 'meet.google.com') {
+			return res
+				.status(400)
+				.send('Unable to join. Invalid Google Meet url value in payload body.');
+		}
 	} catch (e) {
-		return res.status(400).send('Invalid URL provided: ${url}');
+		return res.status(400).send('Unable to join. Invalid URL provided: ${url}');
 	}
 	// Try to spawn a meetbot for location
 	try {
@@ -42,7 +49,7 @@ server.post('/join', async (req, res) => {
 		}
 	}
 	// Meetbot is joining the meet soon
-	return res.status(202).send('A meetbot will be right there');
+	return res.status(202).send('A meetbot will be right there.\n');
 });
 
 server.get('/meets', async (_req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,12 +27,16 @@ server.post('/join', async (req, res) => {
 	try {
 		meetMetadata = new URL(req.body.url);
 		if (meetMetadata.hostname !== 'meet.google.com') {
-			return res
-				.status(400)
-				.send('Unable to join. Invalid Google Meet url value in payload body.');
+			throw new Error(
+				'Unable to join. Invalid Google Meet URL in payload body.',
+			);
 		}
 	} catch (e) {
-		return res.status(400).send('Unable to join. Invalid URL provided: ${url}');
+		return res
+			.status(400)
+			.send(
+				`Unable to join. Invalid Google Meet URL provided: ${req.body.url}`,
+			);
 	}
 	// Try to spawn a meetbot for location
 	try {
@@ -49,7 +53,7 @@ server.post('/join', async (req, res) => {
 		}
 	}
 	// Meetbot is joining the meet soon
-	return res.status(202).send('A meetbot will be right there.\n');
+	return res.status(202).send('A meetbot will be right there.');
 });
 
 server.get('/meets', async (_req, res) => {
@@ -66,7 +70,7 @@ server.post('/leave', async (req, res) => {
 	try {
 		meetMetadata = new URL(req.body.url);
 	} catch (e) {
-		return res.status(400).send('Invalid URL provided: ${url}');
+		return res.status(400).send(`Invalid URL provided: ${req.body.url}`);
 	}
 	// Try to kill meetbot for location
 	try {
@@ -74,14 +78,14 @@ server.post('/leave', async (req, res) => {
 	} catch (e: any) {
 		switch (e.message) {
 			case 'Could not find bot at specified location!':
-				return res.status(400).send('No meetbot found at that location');
+				return res.status(400).send('No meetbot found at that location.');
 			default:
 				console.error(e);
-				return res.status(500).send('Something unexpected happened');
+				return res.status(500).send('Something unexpected happened.');
 		}
 	}
 	// Meetbot will be leaving the meet soon
-	return res.status(202).send('Asking meetbot to leave');
+	return res.status(202).send('Asking meetbot to leave.');
 });
 
 export async function start() {


### PR DESCRIPTION
How it looks like, 

```
➜  ~ curl localhost:8080/join -H "Content-Type: application/json" -d '{"url":"https://google.com/fsdfsdogx-obof-gox"}'
Unable to join. Invalid Google Meet URL in payload body. 
➜  ~ curl localhost:8080/leave -H "Content-Type: application/json" -d '{"url":"fsdfsdogx-obof-gox"}'
Invalid URL provided: fsdfsdogx-obof-gox
➜  ~ curl localhost:8080/join -H "Content-Type: application/json" -d '{"url":212}'
Unable to join. Invalid URL provided: 212
➜  ~ curl localhost:8080/join -H "Content-Type: application/json" -d '{"name":"bond.James."}'  
Unable to join. Missing `url` value in payload body.⏎   
```

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
