### PR TITLE
Return chat transcripts URL

### DIFF
--- a/src/meetbot-manager.ts
+++ b/src/meetbot-manager.ts
@@ -11,6 +11,7 @@ const ACTIVE_BOTS = new Map<string, MeetBot>();
 type MeetBotListItem = {
 	url: string | null;
 	transcriptUrl: string | null;
+	chatTranscriptUrl: string | null;
 	joinedAt: string | null;
 };
 
@@ -29,6 +30,7 @@ export async function listBots() {
 		results.push({
 			url: value.url,
 			transcriptUrl: value.transcriptUrl,
+			chatTranscriptUrl: value.chatTranscriptUrl,
 			joinedAt: value.joinedAt,
 		});
 	});
@@ -62,6 +64,11 @@ export async function spawnBot(url: string) {
 	bot.on('transcript_doc_ready', (data) => {
 		console.log('setting transcript url to' + data.transcriptUrl);
 		bot.transcriptUrl = data.transcriptUrl;
+	});
+
+	bot.on('chat_transcript_doc_ready', (data) => {
+		console.log('setting chat transcript url to' + data.transcriptUrl);
+		bot.chatTranscriptUrl = data.transcriptUrl;
 	});
 
 	bot.on('end', () => {

--- a/src/meetbot/events.ts
+++ b/src/meetbot/events.ts
@@ -35,6 +35,7 @@ interface BotEvents {
 	joined: JoinEvent;
 	active: ActiveEvent;
 	transcript_doc_ready: StreamEvent;
+	chat_transcript_doc_ready: StreamEvent;
 	end: EndEvent;
 	participants: ParticipantsEvent;
 	raw_caption: CaptionEvent;

--- a/src/meetbot/features/chatsave.ts
+++ b/src/meetbot/features/chatsave.ts
@@ -27,10 +27,16 @@ export const attach = (bot: Bot): void => {
 		const docName = `Meeting ${meetId} (${new Date().toISOString()}) Chat`;
 		docId = await doc.create(docName);
 		doc.addTitle('Chat Transcript\n\n');
+
+		const documentUrl = `https://docs.google.com/document/d/${docId}`;
+
+		bot.emit('chat_transcript_doc_ready', {
+			transcriptUrl: documentUrl,
+			meetURL,
+		});
+
 		bot.addJob(
-			postToChatJob(
-				`Chat history is available at: https://docs.google.com/document/d/${docId}`,
-			),
+			postToChatJob(`Chat transcript is available at: ${documentUrl}`),
 		);
 	});
 	bot.on('chat', ({ timestamp, sender, text }) => {

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -35,6 +35,7 @@ class MeetBot implements Bot {
 	public url: string | null = null;
 	public joinedAt: string | null = null;
 	public transcriptUrl: string | null = null;
+	public chatTranscriptUrl: string | null = null;
 
 	private pendingJobs: JobHandler[] = [];
 	private leaveRequested: boolean = false;

--- a/src/ui/src/api/meets/types.d.ts
+++ b/src/ui/src/api/meets/types.d.ts
@@ -4,6 +4,7 @@ export type Meet = {
 	joinedAt: Date;
 	leftAt: Date;
 	transcriptUrl: string | null;
+	chatTranscriptUrl: string | null;
 };
 
 export type MeetsListResponse = {

--- a/src/ui/src/views/Meetings.tsx
+++ b/src/ui/src/views/Meetings.tsx
@@ -138,7 +138,7 @@ const renderMeetTranscriptsColumn = (value: any, row: any): JSX.Element => {
 				Voice
 			</Link>
 			{"  "}
-			<Link href={row.transcriptUrl}>Chat</Link>
+			<Link href={row.chatTranscriptUrl}>Chat</Link>
 		</StyledBox>
 	);
 };


### PR DESCRIPTION
This PR applies the following changes:
- The chat streaming feature now emits an event containing the URL of the document to which messages are saved;
- `meetbot-manager` now waits for the aforementioned event, and associates the chat transcripts URL with the bot that issued it;
- The `/meets` endpoint now returns an extra attribute, corresponding to the chat transcripts URL;
- The UI displays the chat transcripts URL as a link for each ongoing meet.