### PR TITLE
Replace `end` event with `error`

### DIFF
--- a/src/meetbot-manager.ts
+++ b/src/meetbot-manager.ts
@@ -69,9 +69,12 @@ export async function spawnBot(url: string) {
 		bot.chatTranscriptUrl = data.transcriptUrl;
 	});
 
-	bot.on('end', () => {
-		console.log(`Removing ${url} from active bot queue`);
-		ACTIVE_BOTS.delete(url);
+	bot.on('error', (err) => {
+		console.error('Unrecoverable bot error occured:', err.message);
+		if (bot.url && ACTIVE_BOTS.get(bot.url)) {
+			console.log(`Removing ${bot.url} from active bot queue`);
+			ACTIVE_BOTS.delete(bot.url);
+		}
 	});
 
 	// Tell bot to start running

--- a/src/meetbot/events.ts
+++ b/src/meetbot/events.ts
@@ -46,7 +46,7 @@ interface BotEvents {
 	transcript_doc_ready: StreamEvent;
 	chat_transcript_doc_ready: StreamEvent;
 	help_event: HelpEvent;
-	end: EndEvent;
+	error: ErrorEvent;
 	participants: ParticipantsEvent;
 	raw_caption: CaptionEvent;
 	caption: CaptionEvent;

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -214,12 +214,10 @@ class MeetBot implements Bot {
 			}
 		} catch (err) {
 			await this.page.screenshot({ path: 'exception.png' });
-			console.log('ERROR in meet! Exiting...', meetURL, err);
-			this.emit('end', { meetURL });
+			this.emit('error', err as ErrorEvent);
 		} finally {
 			clearInterval(this.captionTimer);
 			await this.page.close();
-			this.emit('end', { meetURL });
 			// TODO detach features?
 		}
 	}


### PR DESCRIPTION
Make this event an error makes it more clear that this event was not suppose to happen. I also removed the double end event being emitted since the finally will always run after the catch. It's possible then that the manager does not know a bot terminated if the try block exits without an error. However, I think the bot should be explicitly emitting an event when it leaves willingly.

Here's an example of the error being catch and logged + bot being removed from active bot list.

```
Initializing meetbot service...
Listening for requests on port 8080
Current bot queue size: 1
typing out email
Unrecoverable bot error occured:  waiting for selector `input[type="emailbruhhh"]` failed: timeout 30000ms exceeded
Removing https://meet.google.com/eaa-ewrq-gdn from active bot queue
```