### PR TITLE
Cleanup events

### DIFF
--- a/src/meetbot-manager.ts
+++ b/src/meetbot-manager.ts
@@ -69,9 +69,12 @@ export async function spawnBot(url: string) {
 		bot.chatTranscriptUrl = data.transcriptUrl;
 	});
 
-	bot.on('end', () => {
-		console.log(`Removing ${url} from active bot queue`);
-		ACTIVE_BOTS.delete(url);
+	bot.on('error', (err) => {
+		console.error('Unrecoverable bot error occured:', err.message);
+		if (bot.url && ACTIVE_BOTS.get(bot.url)) {
+			console.log(`Removing ${bot.url} from active bot queue`);
+			ACTIVE_BOTS.delete(bot.url);
+		}
 	});
 
 	// Tell bot to start running

--- a/src/meetbot-manager.ts
+++ b/src/meetbot-manager.ts
@@ -6,13 +6,14 @@ import { newBrowser } from './browser';
 import { all as allFeatures } from './meetbot/features';
 
 const MAX_BOTS = process.env.MAX_BOTS || 5;
-const ACTIVE_BOTS = new Map<string, MeetBot>();
+const Bots = new Map<string, MeetBot>();
 
 type MeetBotListItem = {
 	url: string | null;
 	transcriptUrl: string | null;
 	chatTranscriptUrl: string | null;
 	joinedAt: string | null;
+	leftAt: string | null;
 };
 
 let browser: Browser | null = null;
@@ -26,12 +27,13 @@ export async function init(): Promise<void> {
 export async function listBots() {
 	const results: MeetBotListItem[] = [];
 
-	ACTIVE_BOTS.forEach((value: MeetBot, _key: string) => {
+	Bots.forEach((value: MeetBot, _key: string) => {
 		results.push({
 			url: value.url,
 			transcriptUrl: value.transcriptUrl,
 			chatTranscriptUrl: value.chatTranscriptUrl,
 			joinedAt: value.joinedAt,
+			leftAt: value.leftAt,
 		});
 	});
 
@@ -43,9 +45,9 @@ export async function spawnBot(url: string) {
 
 	if (meetURL.hostname !== 'meet.google.com') {
 		throw new Error('Invalid Google Meet URL.');
-	} else if (ACTIVE_BOTS.size >= MAX_BOTS) {
+	} else if (Bots.size >= MAX_BOTS) {
 		throw new Error(`Maximum bot queue reached!`);
-	} else if (ACTIVE_BOTS.has(url)) {
+	} else if (Bots.has(url)) {
 		throw new Error(`A bot is already in that location!`);
 	} else if (browser === null) {
 		throw new Error('Browser instance has not been initialized!');
@@ -57,8 +59,8 @@ export async function spawnBot(url: string) {
 	await bot.init();
 
 	bot.on('joined', () => {
-		ACTIVE_BOTS.set(url, bot);
-		console.log(`Current bot queue size: ${ACTIVE_BOTS.size}`);
+		Bots.set(url, bot);
+		console.log(`Current bot queue size: ${Bots.size}`);
 	});
 
 	bot.on('transcript_doc_ready', (data) => {
@@ -70,15 +72,14 @@ export async function spawnBot(url: string) {
 	});
 
 	bot.on('left', () => {
-		console.log(`Removing ${bot.url} from active bot list`);
-		ACTIVE_BOTS.delete(bot.url);
+		// nothing to do when a bot leaves
 	});
 
 	bot.on('error', (err) => {
 		console.error('Unrecoverable bot error occured:', err.message);
-		if (ACTIVE_BOTS.get(bot.url)) {
+		if (Bots.get(bot.url)) {
 			console.log(`Removing ${bot.url} from active bot queue`);
-			ACTIVE_BOTS.delete(bot.url);
+			Bots.delete(bot.url);
 		}
 	});
 
@@ -87,7 +88,7 @@ export async function spawnBot(url: string) {
 }
 
 export async function killBot(url: string) {
-	const bot = ACTIVE_BOTS.get(url);
+	const bot = Bots.get(url);
 	if (bot) {
 		console.log(`Killing bot for ${url}`);
 		bot.leaveMeet();

--- a/src/meetbot-manager.ts
+++ b/src/meetbot-manager.ts
@@ -52,11 +52,11 @@ export async function spawnBot(url: string) {
 	}
 
 	// Create a new bot instance with the already created browser instance
-	const bot = new MeetBot(browser, allFeatures);
+	const bot = new MeetBot(url, browser, allFeatures);
 	// Initialize bot (opens a new page)
 	await bot.init();
 
-	bot.on('active', () => {
+	bot.on('joined', () => {
 		ACTIVE_BOTS.set(url, bot);
 		console.log(`Current bot queue size: ${ACTIVE_BOTS.size}`);
 	});
@@ -69,16 +69,21 @@ export async function spawnBot(url: string) {
 		bot.chatTranscriptUrl = data.transcriptUrl;
 	});
 
+	bot.on('left', () => {
+		console.log(`Removing ${bot.url} from active bot list`);
+		ACTIVE_BOTS.delete(bot.url);
+	});
+
 	bot.on('error', (err) => {
 		console.error('Unrecoverable bot error occured:', err.message);
-		if (bot.url && ACTIVE_BOTS.get(bot.url)) {
+		if (ACTIVE_BOTS.get(bot.url)) {
 			console.log(`Removing ${bot.url} from active bot queue`);
 			ACTIVE_BOTS.delete(bot.url);
 		}
 	});
 
 	// Tell bot to start running
-	bot.joinMeet(url);
+	bot.joinMeet();
 }
 
 export async function killBot(url: string) {

--- a/src/meetbot/events.ts
+++ b/src/meetbot/events.ts
@@ -46,7 +46,7 @@ interface BotEvents {
 	transcript_doc_ready: StreamEvent;
 	chat_transcript_doc_ready: StreamEvent;
 	help_event: HelpEvent;
-	end: EndEvent;
+	error: ErrorEvent;
 	participants: ParticipantsEvent;
 	raw_caption: CaptionEvent;
 	caption: CaptionEvent;

--- a/src/meetbot/events.ts
+++ b/src/meetbot/events.ts
@@ -1,15 +1,12 @@
-interface BotEvent {
-	meetURL: string;
-}
-interface ChatEvent extends BotEvent {
+interface ChatEvent {
 	timestamp: string | null;
 	sender: string | null;
 	text: string;
 }
-interface ParticipantsEvent extends BotEvent {
+interface ParticipantsEvent {
 	participants: number;
 }
-interface CaptionEvent extends BotEvent {
+interface CaptionEvent {
 	caption: SteganographerEvent;
 }
 interface SteganographerEvent {
@@ -20,7 +17,7 @@ interface SteganographerEvent {
 	endedAt: string;
 	id: string;
 }
-interface StreamEvent extends BotEvent {
+interface StreamEvent {
 	transcriptUrl: string | null;
 }
 
@@ -33,16 +30,11 @@ interface HelpEvent {
 	meetbotChatCommands: ChatCommandHelp[];
 }
 
-type LeaveEvent = BotEvent;
-type JoinEvent = BotEvent;
-type ActiveEvent = BotEvent;
-type EndEvent = BotEvent;
-
 interface BotEvents {
 	chat: ChatEvent;
-	left: LeaveEvent;
-	joined: JoinEvent;
-	active: ActiveEvent;
+	left: {};
+	joined: {};
+	joining: {};
 	transcript_doc_ready: StreamEvent;
 	chat_transcript_doc_ready: StreamEvent;
 	help_event: HelpEvent;

--- a/src/meetbot/features/chat-command-help.ts
+++ b/src/meetbot/features/chat-command-help.ts
@@ -1,4 +1,4 @@
-import { Bot } from '..';
+import MeetBot from '..';
 import { postToChatJob } from '../google-meet-helpers';
 import fs = require('fs');
 import { parse } from 'comment-parser';
@@ -24,7 +24,7 @@ function parseChatCommands(): ChatCommandHelp[] {
 /**
  * Print help message for meetbot commands
  */
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	const helpText = parseChatCommands();
 	bot.on('chat', ({ text }) => {
 		if (text === '/help') {

--- a/src/meetbot/features/chat-command-links.ts
+++ b/src/meetbot/features/chat-command-links.ts
@@ -1,10 +1,10 @@
-import { Bot } from '..';
+import MeetBot from '..';
 import { postToChatJob } from '../google-meet-helpers';
 
 /**
  * Sends transcript links to chat again
  */
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	let chatTranscriptUrl: string | null;
 	let transcriptUrl: string | null;
 

--- a/src/meetbot/features/chatlog.ts
+++ b/src/meetbot/features/chatlog.ts
@@ -1,5 +1,5 @@
 import { Page } from 'puppeteer';
-import { Bot } from '..';
+import MeetBot from '..';
 
 interface MessageGroup {
 	timestamp: string;
@@ -21,13 +21,11 @@ class Messenger {
 	}
 }
 
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	let chatHandler: Messenger;
-	let url: string;
 
-	bot.on('joined', ({ meetURL }) => {
+	bot.on('joined', () => {
 		chatHandler = new Messenger();
-		url = meetURL;
 		bot.addJob(monitorChat);
 	});
 
@@ -56,9 +54,7 @@ export const attach = (bot: Bot) => {
 					messages: texts as string[],
 				};
 				const newMessages = chatHandler.updateGroup(messageGroup);
-				newMessages.forEach((m) =>
-					events.push({ meetURL: url, timestamp, sender, text: m }),
-				);
+				newMessages.forEach((m) => events.push({ timestamp, sender, text: m }));
 			}),
 		);
 		for (const event of events) {

--- a/src/meetbot/features/chatsave.ts
+++ b/src/meetbot/features/chatsave.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
-import { Bot } from '..';
+import MeetBot from '..';
 import { Credentials, GoogleDoc } from '../../google/google-doc';
 import { postToChatJob } from '../google-meet-helpers';
 
-export const attach = (bot: Bot): void => {
+export const attach = (bot: MeetBot): void => {
 	let credentials: Credentials | null = null;
 	try {
 		const credentialsFile = fs.readFileSync('credentials.json').toString();
@@ -21,18 +21,15 @@ export const attach = (bot: Bot): void => {
 	const doc = new GoogleDoc(credentials);
 	let docId: string;
 
-	bot.on('joined', async ({ meetURL }) => {
-		const meetId = meetURL.split('/').pop();
+	bot.on('joined', async () => {
+		const meetId = bot.url.split('/').pop();
 		const docName = `Meeting ${meetId} (${new Date().toISOString()}) Chat Transcript`;
 		docId = await doc.create(docName);
 		doc.addTitle('Chat Transcript\n\n');
 
 		const documentUrl = `https://docs.google.com/document/d/${docId}`;
 
-		bot.emit('chat_transcript_doc_ready', {
-			transcriptUrl: documentUrl,
-			meetURL,
-		});
+		bot.emit('chat_transcript_doc_ready', { transcriptUrl: documentUrl });
 
 		bot.addJob(
 			postToChatJob(

--- a/src/meetbot/features/index.ts
+++ b/src/meetbot/features/index.ts
@@ -1,10 +1,10 @@
 import fs = require('fs');
-import { Bot } from '..';
+import MeetBot from '..';
 
 const files = fs.readdirSync(__dirname);
 
 export type Feature = {
-	attach: (bot: Bot) => void;
+	attach: (bot: MeetBot) => void;
 };
 
 export const all: Feature[] = [];

--- a/src/meetbot/features/introduction.ts
+++ b/src/meetbot/features/introduction.ts
@@ -1,13 +1,13 @@
-import { Bot } from '..';
+import MeetBot from '..';
 import { postToChatJob } from '../google-meet-helpers';
 
 const GREETING_MESSAGE =
 	process.env.GREETING_MESSAGE ||
 	"Hello folks, it's your favorite bot, hubot!!";
 
-export const attach = (bot: Bot) => {
-	bot.on('joined', ({ meetURL }) => {
-		console.log('Joined the meeting: ', meetURL);
+export const attach = (bot: MeetBot) => {
+	bot.on('joined', () => {
+		console.log('Joined the meeting: ', bot.url);
 		bot.addJob(
 			postToChatJob(
 				GREETING_MESSAGE + `\n(Type /help for available chat commands)`,
@@ -15,7 +15,7 @@ export const attach = (bot: Bot) => {
 		);
 	});
 
-	bot.on('left', ({ meetURL }) => {
-		console.log('Leaving the meeting:', meetURL);
+	bot.on('left', () => {
+		console.log('Leaving the meeting:', bot.url);
 	});
 };

--- a/src/meetbot/features/record.ts
+++ b/src/meetbot/features/record.ts
@@ -1,8 +1,8 @@
 import { Page } from 'puppeteer-extra-plugin/dist/puppeteer';
-import { Bot } from '..';
+import MeetBot from '..';
 import { clickText } from '../google-meet-helpers';
 
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	bot.on('joined', () => {
 		console.log('queuing: starting the recording...');
 		bot.addJob(startRecording);

--- a/src/meetbot/features/storage.ts
+++ b/src/meetbot/features/storage.ts
@@ -1,10 +1,10 @@
 import { promises as fs } from 'fs';
-import { Bot } from '..';
+import MeetBot from '..';
 
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	let filename: string | null;
-	bot.on('joined', (joined) => {
-		const id = joined.meetURL.split('/').pop();
+	bot.on('joined', () => {
+		const id = bot.url.split('/').pop();
 		filename = `meet-${id}.log`;
 	});
 

--- a/src/meetbot/features/stream.ts
+++ b/src/meetbot/features/stream.ts
@@ -1,10 +1,10 @@
-import { Bot } from '..';
+import MeetBot from '..';
 import * as fs from 'fs';
 import * as moment from 'moment';
 import { postToChatJob } from '../google-meet-helpers';
 import { Credentials, GoogleDoc } from '../../google/google-doc';
 
-export const attach = async (bot: Bot) => {
+export const attach = async (bot: MeetBot) => {
 	let credentials: Credentials | null = null;
 	try {
 		const credentialsFile = fs.readFileSync('credentials.json').toString();
@@ -22,17 +22,14 @@ export const attach = async (bot: Bot) => {
 	const doc = new GoogleDoc(credentials);
 	let docId: string;
 
-	bot.on('joined', async ({ meetURL }) => {
-		const meetId = meetURL.split('/').pop();
+	bot.on('joined', async () => {
+		const meetId = bot.url.split('/').pop();
 		const docName = `Meeting ${meetId} (${new Date().toISOString()}) Voice Transcript`;
 		docId = await doc.create(docName);
 		doc.addTitle('Transcript\n\n');
 		const documentUrl = `https://docs.google.com/document/d/${docId}`;
 
-		bot.emit('transcript_doc_ready', {
-			transcriptUrl: documentUrl,
-			meetURL,
-		});
+		bot.emit('transcript_doc_ready', { transcriptUrl: documentUrl });
 
 		bot.addJob(postToChatJob(`Meet Transcript: ${documentUrl}`));
 	});

--- a/src/meetbot/features/validate-audio-input.ts
+++ b/src/meetbot/features/validate-audio-input.ts
@@ -1,9 +1,9 @@
-import { Bot } from '..';
+import MeetBot from '..';
 import { postToChatJob } from '../google-meet-helpers';
 
 // Feature to auto validate audio input from attendees in meetings when folks ask the question: Can you hear me?
 
-export const attach = (bot: Bot) => {
+export const attach = (bot: MeetBot) => {
 	let sayHelloInProgress = 0;
 	bot.on('raw_caption', ({ caption }) => {
 		if (!caption) {

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -31,6 +31,7 @@ class MeetBot implements Bot {
 	public page: Page | null = null;
 	public url: string;
 	public joinedAt: string | null = null;
+	public leftAt: string | null = null;
 	public transcriptUrl: string | null = null;
 	public chatTranscriptUrl: string | null = null;
 
@@ -215,6 +216,7 @@ class MeetBot implements Bot {
 		} finally {
 			clearInterval(this.captionTimer);
 			await this.page.close();
+			this.leftAt = new Date().toUTCString();
 			this.emit('left', null);
 			// TODO detach features?
 		}

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -173,6 +173,13 @@ class MeetBot implements Bot {
 			console.log('streaming captions');
 
 			while (!this.leaveRequested) {
+				const removedMessage = await this.page.$x(
+					'//div[text()="You\'ve been removed from the meeting"]',
+				);
+				if (removedMessage.length > 0) {
+					this.leaveRequested = true;
+					break;
+				}
 				await this.page.waitForTimeout(500);
 
 				// names of participants in list

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -214,12 +214,10 @@ class MeetBot implements Bot {
 			}
 		} catch (err) {
 			await this.page.screenshot({ path: 'exception.png' });
-			console.log('ERROR in meet! Exiting...', meetURL, err);
-			this.emit('end', { meetURL });
+			this.emit('error', err as ErrorEvent);
 		} finally {
 			clearInterval(this.captionTimer);
 			await this.page.close();
-			this.emit('end', { meetURL });
 			// TODO detach features?
 		}
 	}


### PR DESCRIPTION
989b9d16c3b65b36c440f3db8b2786c63c7169ea - Making the `end` event an `error` makes it more clear that this event was not suppose to happen. I also removed the double end event being emitted since the finally will always run after the catch.

Here's an example of the error being catch and logged + bot being removed from active bot list.

```
Initializing meetbot service...
Listening for requests on port 8080
Current bot queue size: 1
typing out email
Unrecoverable bot error occured:  waiting for selector `input[type="emailbruhhh"]` failed: timeout 30000ms exceeded
Removing https://meet.google.com/eaa-ewrq-gdn from active bot queue
```

8f01e85bdcb6a620172a699639fd523b3e6896d7 -  The events were passing url data when the bot itself had a url property. I also made the left event trigger the manager to remove the bot.

7d44e65ce2b345caa677bd3b055b82847bfbc4a5 - the bot previously never knew when it was kicked. This uses an XPATH that searches for a div with text. It seems much more robust the our other selectors...worth switching them all to this since we no longer depend on classes which all appear dynamically generated by Google.

c54532ff088f78cf3e1692690368d89ca8cf1537 - sets a `leftAt` timestamp so we can track when a bot has left a meet.