### PR TITLE
patch: Add optional chaining to events without meets

### DIFF
--- a/src/google/google-calendar.ts
+++ b/src/google/google-calendar.ts
@@ -60,7 +60,7 @@ export class GoogleCalendar {
 		return events.data.items
 			.filter(
 				(item: any) =>
-					item.hangoutLink.includes('meet.google.com') &&
+					item.hangoutLink?.includes('meet.google.com') &&
 					item.status === 'confirmed',
 			)
 			.map((event: any) => {


### PR DESCRIPTION
Was getting the error `(node:32) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'includes' of undefined` for calendar events without a hangoutLink. Added optional chaining instructor to bypass to account for those events. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
