### PR TITLE
minor: Abstract logic to check number of people in the call

### DIFF
--- a/src/meetbot/events.ts
+++ b/src/meetbot/events.ts
@@ -3,8 +3,8 @@ interface ChatEvent {
 	sender: string | null;
 	text: string;
 }
-interface ParticipantsEvent {
-	participants: number;
+interface PeopleInMeetEvent {
+	peopleInMeet: number;
 }
 interface CaptionEvent {
 	caption: SteganographerEvent;
@@ -39,7 +39,7 @@ interface BotEvents {
 	chat_transcript_doc_ready: StreamEvent;
 	help_event: HelpEvent;
 	error: ErrorEvent;
-	participants: ParticipantsEvent;
+	peopleInMeet: PeopleInMeetEvent;
 	raw_caption: CaptionEvent;
 	caption: CaptionEvent;
 }

--- a/src/meetbot/features/record.ts
+++ b/src/meetbot/features/record.ts
@@ -1,6 +1,6 @@
 import { Page } from 'puppeteer-extra-plugin/dist/puppeteer';
 import MeetBot from '..';
-import { clickText } from '../google-meet-helpers';
+import { clickText, peopleInMeet } from '../google-meet-helpers';
 
 export const attach = (bot: MeetBot) => {
 	bot.on('joined', () => {
@@ -20,6 +20,11 @@ const startRecording = async (page: Page) => {
 			'Recording is already turned on. Not trying to start recording.',
 		);
 		return;
+	}
+
+	while ((await peopleInMeet(page)).length <= 2) {
+		// console.log("Only 2 people in the call including me so not recording")
+		// Will wait for more people to join
 	}
 
 	console.log('Starting the recording...');

--- a/src/meetbot/google-meet-helpers.ts
+++ b/src/meetbot/google-meet-helpers.ts
@@ -41,5 +41,7 @@ export const postToChatJob = (text: string) => {
 };
 
 export const peopleInMeet = async (page: Page) => {
-	return await page.$$('span.zWGUib');
+	return (await page.$$('span.zWGUib'))
+		? await page.$$('span.zWGUib')
+		: Promise.reject(new Error('peopleInMeet function failed'));
 };

--- a/src/meetbot/google-meet-helpers.ts
+++ b/src/meetbot/google-meet-helpers.ts
@@ -39,3 +39,7 @@ export const postToChatJob = (text: string) => {
 		console.log('Message sent on the chat');
 	};
 };
+
+export const peopleInMeet = async (page: Page) => {
+	return await page.$$('span.zWGUib');
+};

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -8,7 +8,6 @@ import totp = require('totp-generator');
 
 import { promises as fs } from 'fs';
 import * as path from 'path';
-import { people } from 'googleapis/build/src/apis/people';
 
 export type JobHandler = (page: Page) => Promise<void>;
 export type JobQueueFunc = (h: JobHandler) => void;
@@ -127,6 +126,7 @@ class MeetBot implements Bot {
 			// If meetbot is alone when it joins then kill the bot
 			if ((await peopleInMeet(this.page)).length === 1) {
 				console.log("nobody else is here - I'm leaving...");
+				// Making sure when this logic breaks, we know about it.
 				throw new Error('nobody else is here - I am leaving');
 			}
 

--- a/src/meetbot/index.ts
+++ b/src/meetbot/index.ts
@@ -3,11 +3,12 @@ import { Browser, Page } from 'puppeteer';
 
 import { newPage } from '../browser';
 import { Feature } from './features';
-import { clickText } from './google-meet-helpers';
+import { clickText, peopleInMeet } from './google-meet-helpers';
 import totp = require('totp-generator');
 
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { people } from 'googleapis/build/src/apis/people';
 
 export type JobHandler = (page: Page) => Promise<void>;
 export type JobQueueFunc = (h: JobHandler) => void;
@@ -123,10 +124,8 @@ class MeetBot implements Bot {
 				await this.page.waitForXPath("//*[contains(text(),'call_end')]");
 			}
 
-			// If meetbot is alone then leave
-			const peopleInMeet = await this.page.$$('span.zWGUib');
-
-			if (peopleInMeet.length === 1) {
+			// If meetbot is alone when it joins then kill the bot
+			if ((await peopleInMeet(this.page)).length === 1) {
 				console.log("nobody else is here - I'm leaving...");
 				throw new Error('nobody else is here - I am leaving');
 			}
@@ -200,10 +199,11 @@ class MeetBot implements Bot {
 				await this.page.waitForTimeout(500);
 
 				// names of participants in list
-				const participants = await this.page.$$('span.zWGUib');
-				this.emit('participants', { participants: participants.length });
+				this.emit('peopleInMeet', {
+					peopleInMeet: (await peopleInMeet(this.page)).length,
+				});
 
-				if (participants.length === 1) {
+				if ((await peopleInMeet(this.page)).length === 1) {
 					console.log("nobody else is here - I'm leaving...");
 					break;
 				}


### PR DESCRIPTION
PR contains 2 improvements:

1. Recording for calls will only start when 2 people have joined: Resolves https://github.com/balena-io-playground/meetbot/issues/79
2. Abstracted away logic to find how many people are there in the call 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
