### PR TITLE
patch: Reboot voicebot every week

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2.1"
+volumes:
+  scripts:
+services:
+  meetbot:
+    labels:
+      io.balena.features.supervisor-api: '1'
+    context: . 
+    ports:
+      - "80:80"
+  cron:
+    restart: always
+    image: ghcr.io/rcooke-warwick/cron:latest
+    volumes:
+      - "scripts:/data"
+    ports:
+      - "80:3000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3093,9 +3093,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,15 @@
 import * as server from './server';
+import axios from 'axios';
 
 console.log('Initializing meetbot service...');
+console.log('Registering weekly restart...');
+
+axios.post(
+	`https://${process.env.BALENA_DEVICE_UUID}.balena-devices.com/createjob`,
+	{
+		minute: '0 11 * * 1',
+		command: `curl -X POST --header "Content-Type:application/json" ${process.env.BALENA_SUPERVISOR_ADDRESS}/v1/reboot?apikey=${process.env.BALENA_SUPERVISOR_API_KEY}`,
+	},
+);
 
 server.start();


### PR DESCRIPTION
This is just a workaround to a bigger problem which happens after every week meetbot is operational for. On every Monday, Meetbot is not able to spawn bots for the meetings and leads to a state where the only resolution is to restart all services on the device and then it works fine. Since meetbot is deemed to run on a low-maintenance mode, I thought I add this workaround to automate the restart of the services by rebooting the machine.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
